### PR TITLE
Implement login and signup screens using shared components and Firebase

### DIFF
--- a/screens/LoginScreen.tsx
+++ b/screens/LoginScreen.tsx
@@ -1,22 +1,78 @@
-import React from 'react';
-import { View, Text, Button } from 'react-native';
-import { signInAnonymously } from 'firebase/auth';
+import React, { useState } from 'react';
+import { View, Text, TouchableOpacity } from 'react-native';
+import { signInWithEmailAndPassword } from 'firebase/auth';
+import { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import { useNavigation } from '@react-navigation/native';
 
+import AppInput from '../components/AppInput';
+import AppButton from '../components/AppButton';
 import { auth } from '../lib/firebase';
+import { validateEmail, showToast } from '@/utils';
+import { AuthStackParamList } from '../navigation/AuthStack';
 
 export default function LoginScreen() {
+  const navigation =
+    useNavigation<NativeStackNavigationProp<AuthStackParamList>>();
+
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [loading, setLoading] = useState(false);
+
   const handleLogin = async () => {
+    if (!validateEmail(email)) {
+      showToast('Please enter a valid email');
+      return;
+    }
+    if (!password) {
+      showToast('Please enter your password');
+      return;
+    }
+
+    setLoading(true);
     try {
-      await signInAnonymously(auth);
-    } catch (e) {
-      console.warn('Login failed', e);
+      await signInWithEmailAndPassword(auth, email, password);
+    } catch (e: any) {
+      showToast(e.message || 'Login failed');
+    } finally {
+      setLoading(false);
     }
   };
 
   return (
-    <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
-      <Text>Login Screen</Text>
-      <Button title="Login" onPress={handleLogin} />
+    <View className="flex-1 justify-center px-4">
+      <AppInput
+        label="Email"
+        value={email}
+        onChangeText={setEmail}
+        autoCapitalize="none"
+        keyboardType="email-address"
+        className="mb-4"
+      />
+      <AppInput
+        label="Password"
+        value={password}
+        onChangeText={setPassword}
+        secureTextEntry
+        autoCapitalize="none"
+        className="mb-4"
+      />
+      <AppButton
+        onPress={handleLogin}
+        loading={loading}
+        disabled={loading}
+        className="mt-2"
+      >
+        Log In
+      </AppButton>
+      <TouchableOpacity
+        onPress={() => navigation.navigate('SignUp')}
+        className="mt-4"
+        disabled={loading}
+      >
+        <Text className="text-center text-blue-600">
+          Don't have an account? Sign Up
+        </Text>
+      </TouchableOpacity>
     </View>
   );
 }

--- a/screens/SignUpScreen.tsx
+++ b/screens/SignUpScreen.tsx
@@ -1,10 +1,78 @@
-import React from 'react';
-import { View, Text } from 'react-native';
+import React, { useState } from 'react';
+import { View, Text, TouchableOpacity } from 'react-native';
+import { createUserWithEmailAndPassword } from 'firebase/auth';
+import { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import { useNavigation } from '@react-navigation/native';
+
+import AppInput from '../components/AppInput';
+import AppButton from '../components/AppButton';
+import { auth } from '../lib/firebase';
+import { validateEmail, showToast } from '@/utils';
+import { AuthStackParamList } from '../navigation/AuthStack';
 
 export default function SignUpScreen() {
+  const navigation =
+    useNavigation<NativeStackNavigationProp<AuthStackParamList>>();
+
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  const handleSignUp = async () => {
+    if (!validateEmail(email)) {
+      showToast('Please enter a valid email');
+      return;
+    }
+    if (password.length < 6) {
+      showToast('Password must be at least 6 characters');
+      return;
+    }
+
+    setLoading(true);
+    try {
+      await createUserWithEmailAndPassword(auth, email, password);
+    } catch (e: any) {
+      showToast(e.message || 'Sign up failed');
+    } finally {
+      setLoading(false);
+    }
+  };
+
   return (
-    <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
-      <Text>Sign Up Screen</Text>
+    <View className="flex-1 justify-center px-4">
+      <AppInput
+        label="Email"
+        value={email}
+        onChangeText={setEmail}
+        autoCapitalize="none"
+        keyboardType="email-address"
+        className="mb-4"
+      />
+      <AppInput
+        label="Password"
+        value={password}
+        onChangeText={setPassword}
+        secureTextEntry
+        autoCapitalize="none"
+        className="mb-4"
+      />
+      <AppButton
+        onPress={handleSignUp}
+        loading={loading}
+        disabled={loading}
+        className="mt-2"
+      >
+        Create Account
+      </AppButton>
+      <TouchableOpacity
+        onPress={() => navigation.navigate('Login')}
+        className="mt-4"
+        disabled={loading}
+      >
+        <Text className="text-center text-blue-600">
+          Already have an account? Log In
+        </Text>
+      </TouchableOpacity>
     </View>
   );
 }


### PR DESCRIPTION
## Summary
- Replace placeholder login with email/password form using AppInput and AppButton
- Add full signup form with validation and Firebase auth
- Link login and signup screens for easy navigation

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_688d3a1596408332b2eff8a5392ecdfb